### PR TITLE
Allow user code to specify property whitelist via _inspector

### DIFF
--- a/src/pixi.inspector.js
+++ b/src/pixi.inspector.js
@@ -19,7 +19,7 @@
 	}
 
 	var inspector = {
-		
+
 		selectMode: false,
 
 		_highlight: {
@@ -103,7 +103,7 @@
 			if (this._highlight.point) {
 				this._highlight.node = this.highlightAt(stage, this._highlight.point);
 			}
-			var highlightNode = this._highlight.node;  
+			var highlightNode = this._highlight.node;
 			if (this._highlight.graphics && highlightNode && highlightNode.getBounds) {
 				var box = this._highlight.graphics;
 				box.clear();
@@ -181,7 +181,7 @@
 						this.node(node);
 						node._inspector.collapsed = false;
 						return result;
-					}	
+					}
 				}
 			}
 			if (node.getBounds && node.getBounds().contains(point.x, point.y)) {
@@ -225,7 +225,14 @@
 			var formatted = {
 				_inspector: window.$pixi._inspector
 			};
-			Object.keys(window.$pixi).forEach(function (property) {
+
+			var properties = Object.keys(window.$pixi);
+
+			if (formatted._inspector !== undefined && formatted._inspector.whitelist !== undefined) {
+				properties = formatted._inspector.whitelist;
+			}
+
+			properties.forEach(function (property) {
 				if (property[0] === '_' || ['children', 'parent'].indexOf(property) !== -1) {
 					return;
 				}
@@ -314,15 +321,18 @@
 			return false;
 		},
 		node: function (node) {
-			var inspector = node._inspector;
-			if (!inspector) {
-				inspector = {
-					id: this.generateId(),
-					collapsed: true,
-					type: this.detectType(node)
-				};
-				node._inspector = inspector;
-			}
+			var inspector = node._inspector || {};
+
+			var defaultTo = function (obj, prop, value) {
+				if (obj[prop] === undefined) { obj[prop] = value; }
+			};
+
+			defaultTo(inspector, 'id', this.generateId());
+			defaultTo(inspector, 'collapsed', true);
+			defaultTo(inspector, 'type', this.detectType(node));
+
+			node._inspector = inspector;
+
 			var result = {
 				id: inspector.id,
 				type: inspector.type,
@@ -330,7 +340,7 @@
 				collapsed: inspector.collapsed,
 				name: node.name
 			};
-	
+
 			if (result.leaf === false && inspector.collapsed === false) {
 				result.children = [];
 				var length = node.children.length;
@@ -344,7 +354,7 @@
 		generateId: function () {
 			this._autoincrement++;
 			return this._autoincrement;
-		}, 
+		},
 		detectType: function (node) {
 			if (!node.constructor) {
 				return 'Unknown';
@@ -382,7 +392,7 @@
 				case PIXI.SpriteBatch: return 'PIXI.SpriteBatch';
 				case PIXI.AssetLoader: return 'PIXI.AssetLoader';
 			}
-			var versionMajor = parseInt(PIXI.VERSION, 10) || 1; 
+			var versionMajor = parseInt(PIXI.VERSION, 10) || 1;
 			if (versionMajor < 3) { // Deprecated (PIXI v2)
 				switch (node.constructor) {
 					case PIXI.Stage: return 'PIXI.Stage';
@@ -585,9 +595,9 @@
 				}
 			}
 			return 'Unknown';
-	
+
 		},
-		
+
 		use: function (_PIXI) {
 			PIXI = _PIXI;
 			inspector.patch(PIXI.CanvasRenderer);

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,12 +15,13 @@
              view: document.getElementById('example')
          });
 
-        
-        
         // create an new instance of a pixi stage
         var stage = new PIXI.Container();
 
-
+        stage._inspector = {
+          type: 'stage',
+          whitelist: ['position']
+        };
 
         // create a background texture
         var pondFloorTexture = PIXI.Texture.fromImage("http://www.goodboydigital.com/pixijs/examples/17/BGrotate.jpg");
@@ -28,15 +29,15 @@
         var pondFloorSprite = new PIXI.Sprite(pondFloorTexture);
         stage.addChild(pondFloorSprite);
 
-        
+
         var dudesContainer = new PIXI.Container();
         stage.addChild(dudesContainer);
         // create an array to store a refference to the fish in the pond
         var dudeArray = [];
-         
+
         var totalDude = 10;
 
-        for (var i = 0; i < totalDude; i++) 
+        for (var i = 0; i < totalDude; i++)
         {
 
             // create a new Sprite that uses the image name that we just generated as its source
@@ -47,11 +48,11 @@
 
             // set a random scale for the dude - no point them all being the same size!
             dude.scale.x = dude.scale.y = 0.8 + Math.random() * 0.3;
-            
+
             // finally lets set the dude to be a random position..
             dude.position.x = Math.random() * viewWidth;
             dude.position.y = Math.random() * viewHeight;
-        
+
             // time to add the dude to the pond container!
             dudesContainer.addChild(dude);
 
@@ -66,21 +67,21 @@
             dude.turningSpeed = Math.random() - 0.8;
 
             // create a random speed for the dude between 0 - 2
-            dude.speed = 2 + Math.random() * 2; 
+            dude.speed = 2 + Math.random() * 2;
 
             // finally we push the dude into the dudeArray so it it can be easily accessed later
             dudeArray.push(dude);
 
         }
 
-        // create a bounding box box for the little dudes 
+        // create a bounding box box for the little dudes
         var dudeBoundsPadding = 100;
         var dudeBounds = new PIXI.Rectangle(-dudeBoundsPadding,
-                                            -dudeBoundsPadding, 
-                                            viewWidth + dudeBoundsPadding * 2, 
+                                            -dudeBoundsPadding,
+                                            viewWidth + dudeBoundsPadding * 2,
                                             viewHeight + dudeBoundsPadding * 2);
 
-        
+
 
         // create a displacment map
 
@@ -88,10 +89,10 @@
         var tick = 0;
         requestAnimationFrame(animate);
 
-        function animate() 
+        function animate()
         {
             // iterate through the dude and update the positiond
-            for (var i = 0; i < dudeArray.length; i++) 
+            for (var i = 0; i < dudeArray.length; i++)
             {
                 var dude = dudeArray[i];
                 dude.direction += dude.turningSpeed * 0.01;
@@ -102,19 +103,19 @@
                 // wrap the dudes by testing there bounds..
                 if(dude.position.x < dudeBounds.x)dude.position.x += dudeBounds.width;
                 else if(dude.position.x > dudeBounds.x + dudeBounds.width)dude.position.x -= dudeBounds.width
-                
+
                 if(dude.position.y < dudeBounds.y)dude.position.y += dudeBounds.height;
                 else if(dude.position.y > dudeBounds.y + dudeBounds.height)dude.position.y -= dudeBounds.height
             }
-            
+
             // increment the ticker
             tick += 0.1;
-            
-            
-            
+
+
+
             // time to render the state!
             renderer.render(stage);
-            
+
             // request another animation frame..
             requestAnimationFrame( animate );
         }
@@ -126,7 +127,7 @@
             <!-- this is where the root react component will get rendered -->
         </div>
     </div>
-    
+
     <script src="http://localhost:8090/node_modules/react/dist/react-with-addons.js"></script>
     <script src="http://localhost:8090/node_modules/react-dom/dist/react-dom.js"></script>
     <script src="http://localhost:8090/node_modules/rx/dist/rx.all.js"></script>


### PR DESCRIPTION
This allows a user to specify a whitelist of properties to be displayed in the inspector, to avoid browsing the full list of default properties on a PIXI display object.

![image](https://cloud.githubusercontent.com/assets/6932310/15037204/c8ee8ca6-124d-11e6-8944-6ab75a5e2c7a.png)

I also made a change to the `node` function with the intention of making `node._inspector` a safe place for user code to attach inspector-related metadata (I also use it to specify the displayed `type` of a node in the updated test file).