### PR TITLE
Add support for pixi v5 renderer

### DIFF
--- a/src/services/Inspector.js
+++ b/src/services/Inspector.js
@@ -44,6 +44,10 @@ export default class Inspector {
     if (!this.unpatched.WebGLRenderer) {
       this.patch("WebGLRenderer");
     }
+    // Support for pixi v5
+    if (!this.unpatched.Renderer) {
+      this.patch("Renderer");
+    }
     this.enabled$.next(true);
   }
 

--- a/src/services/InspectorGui.js
+++ b/src/services/InspectorGui.js
@@ -221,9 +221,13 @@ export default class InspectorGui {
       resolution: window.devicePixelRatio,
       view: canvas
     };
-    if (overlay.PIXI.WebGLRenderer.length === 1) {
+    let overlayRendererType = overlay.PIXI.WebGLRenderer;
+    if (typeof overlay.PIXI.Renderer !== "undefined") {
+      overlayRendererType = overlay.PIXI.Renderer;
+    }
+    if (overlayRendererType.length === 1) {
       // Expects a Phaser Game object?
-      overlay.renderer = new overlay.PIXI.WebGLRenderer(
+      overlay.renderer = new overlayRendererType(
         Object.assign(
           {
             canvas,
@@ -237,7 +241,7 @@ export default class InspectorGui {
         )
       );
     } else {
-      overlay.renderer = new overlay.PIXI.WebGLRenderer(
+      overlay.renderer = new overlayRendererType(
         window.innerWidth,
         window.innerHeight,
         options


### PR DESCRIPTION
Added support for Pixi v5 renderer, tested with version 5.1.0 and 4.8.2.
Pixi still has to be accessible on window `window.PIXI = PIXI;`