### PR TITLE
Fix scaling for highlighting objects (#26)

### DIFF
--- a/src/services/InspectorHighlight.js
+++ b/src/services/InspectorHighlight.js
@@ -38,9 +38,10 @@ export default class InspectorHighlight {
       box.beginFill(0x007eff, 0.3);
       box.lineStyle(1, 0x007eff, 0.6);
       const bounds = node.getBounds();
+      const canvasScale = InspectorHighlight.getHtmlElementScale(renderer.view);
       const scale = {
-        x: this.gui.resolution.x / renderer.resolution,
-        y: this.gui.resolution.y / renderer.resolution,
+        x: (renderer.view.offsetWidth * canvasScale) / renderer.screen.width,
+        y: (renderer.view.offsetHeight * canvasScale) / renderer.screen.height,
       };
       box.drawRect(
         bounds.x * scale.x,
@@ -69,6 +70,24 @@ export default class InspectorHighlight {
     } else {
       box.visible = false;
     }
+  }
+
+  static getHtmlElementScale(element) {
+    if (!window.getComputedStyle || !element) return 1;
+
+    const { transform } = window.getComputedStyle(element);
+
+    const transformMatrix3d = transform.match(/^matrix3d\((.+)\)$/);
+
+    if (transformMatrix3d)
+      return parseFloat(transformMatrix3d[1].split(", ")[13]);
+
+    const transformMatrix2d = transform.match(/^matrix\((.+)\)$/);
+
+    if (transformMatrix2d)
+      return parseFloat(transformMatrix2d[1].split(", ")[3]);
+
+    return 1;
   }
 }
 


### PR DESCRIPTION
This new calculation takes into account both canvas size and its computed style transform.

Tested in two full games using PixiJS v4 and v6.

Fixes #26 too:

Before:
![image](https://user-images.githubusercontent.com/418083/129951001-dafb9912-a674-431b-b368-ad0a6857733f.png)

After:
![image](https://user-images.githubusercontent.com/418083/129951051-93022e43-8784-4b70-b34d-090e7e5e791d.png)
