### PR TITLE
feat(pixi): add some support for stageless environments

### DIFF
--- a/packages/pixi-panel/src/pixi-devtools/pixiDevtools.ts
+++ b/packages/pixi-panel/src/pixi-devtools/pixiDevtools.ts
@@ -46,6 +46,10 @@ export default function pixiDevtools() {
       if (game) {
         return game.scene.scenes[0];
       }
+      const renderer = getGlobal("__PIXI_RENDERER__");
+      if (renderer) {
+        return renderer.lastObjectRendered;
+      }
       return undefined;
     },
     renderer(): IRenderer<ICanvas> | Game | undefined {


### PR DESCRIPTION
If you have a stageless environment that calls `render` a lot of times, you might not have a stage. For that purpose, `lastObjectRendered` is a reference to the last container that was rendered manually by calling `renderer.render(thisIsWhatIsStored)` It might not be what people need, but it will be something instead of just failing alltogether Fun fact: `lastObjectRendered` is what Interaction and FederatedEvents use to detect on which object you are clicking: https://github.com/pixijs/pixijs/blob/05097a87bf67a8e3b9dd051978f8692f116f5cdc/packages/events/src/EventSystem.ts#L233