### PR TITLE
feat: specify number input element type

### DIFF
--- a/packages/blender-elements/NumberInput.svelte
+++ b/packages/blender-elements/NumberInput.svelte
@@ -60,7 +60,7 @@
 
 <input
   {id}
-  type='number'
+  type="number"
   class="number-input"
   data-location={location}
   use:blurOnEnter

--- a/packages/blender-elements/NumberInput.svelte
+++ b/packages/blender-elements/NumberInput.svelte
@@ -60,6 +60,7 @@
 
 <input
   {id}
+  type='number'
   class="number-input"
   data-location={location}
   use:blurOnEnter


### PR DESCRIPTION
Specification of type for _number input element_ gives us two main advantages:
- Input values filtering. So it is not possible anymore to put there anything that is not used in number representation.
- It gives ability to user to increment and decrement value with spinner buttons on input element or with up, down arrow keys (that was my main goal).