### PR TITLE
fix(chrome): allow all urls host permissions

### DIFF
--- a/apps/chrome-extension/src/manifest.json
+++ b/apps/chrome-extension/src/manifest.json
@@ -7,5 +7,6 @@
   "icons": {
     "16": "icon.png",
     "48": "icon.png"
-  }
+  },
+  "host_permissions": ["<all_urls>"]
 }


### PR DESCRIPTION
When installing the extension form the Chrome store, the extension appears greyed-out. When checking the extension's settings, "Can't Read or Change Site's Data" is shown.

Using: Chrome 117.0.5938.92

<img width="218" alt="image" src="https://github.com/bfanger/pixi-inspector/assets/35539750/397ba76a-fd2a-44ae-bd02-edb5bd57d259">

According to Chrome's documentation, this access is dictated by the "host_permissions" field: https://developer.chrome.com/docs/extensions/mv3/declare_permissions/#host-permissions

Updating this in the Chrome manifest will trigger a warning to users when they update the extension. Since I do not see any existing issues on the repository about the extension not working, so it is possible this change is not needed, and is due to my own machine's configuration. 

Regardless, I will offer this PR as a fix if anyone needs it. It may be possible that the latest version of Chrome has made the permissions more stringent.