### PR TITLE
fix: Fail gracefully when calling __UI_PROTOCOL__-member before ui protocol has been created

### DIFF
--- a/packages/ui-protocol/src/evalBridge.ts
+++ b/packages/ui-protocol/src/evalBridge.ts
@@ -43,7 +43,7 @@ export async function evalConnect(
 ): Promise<Connection> {
   const connectInterval = options?.connectInterval ?? 1_000;
   const signal = options?.signal ?? new AbortController().signal;
-  const target = `__UI_PROTOCOL__[${JSON.stringify(id)}]`;
+  const target = `window.__UI_PROTOCOL__?.[${JSON.stringify(id)}]`;
   const connected = Promise.withResolvers<void>();
   let timer: ReturnType<typeof setTimeout> | undefined = undefined;
 


### PR DESCRIPTION
When running the devtools with "Pause on exceptions" on in Firefox it always crashes on load. This should allow that to not happen as it does not appear to impact functionality in any meaningful way.