### PR TITLE
fix: periodically re-scan frames to detect cross-origin iframes

### DIFF
--- a/apps/chrome-extension/src/pixi-panel.ts
+++ b/apps/chrome-extension/src/pixi-panel.ts
@@ -10,8 +10,6 @@ function createListener(
   setUrls: (urls: string[]) => void,
   setRefresh: (fn: () => void) => void,
 ) {
-  let lastFrameUrls = "";
-
   function refresh() {
     chrome.devtools.inspectedWindow.getResources((resources) => {
       let firstDocument = true;
@@ -25,12 +23,7 @@ function createListener(
           }
         }
       }
-      const urls = Array.from(frameUrls);
-      const key = urls.join("\n");
-      if (key !== lastFrameUrls) {
-        lastFrameUrls = key;
-        setUrls(urls);
-      }
+      setUrls(Array.from(frameUrls));
     });
   }
   refresh();
@@ -44,9 +37,8 @@ function createListener(
   chrome.devtools.inspectedWindow.onResourceAdded.addListener(callback);
 
   // Periodically re-scan for frames that onResourceAdded may have missed
-  // (common with cross-origin iframes loaded after initial page render).
-  // The lastFrameUrls dedup ensures setUrls only fires when the frame list
-  // actually changes, making this a no-op once frames stabilize.
+  // (common with cross-origin iframes loaded after initial page render)
+  // or whose contexts were invalidated by page reload/navigation.
   const rescanInterval = setInterval(refresh, 2_000);
 
   return () => {

--- a/apps/chrome-extension/src/pixi-panel.ts
+++ b/apps/chrome-extension/src/pixi-panel.ts
@@ -10,6 +10,24 @@ function createListener(
   setUrls: (urls: string[]) => void,
   setRefresh: (fn: () => void) => void,
 ) {
+  // Discover all iframe URLs by probing the DOM recursively.
+  // This catches nested iframes that getResources/onResourceAdded miss
+  // after navigation (a Chrome DevTools bug with nested cross-origin frames).
+  const discoverFramesCode = `(function() {
+    var urls = [];
+    function walk(doc) {
+      try {
+        var frames = doc.querySelectorAll('iframe');
+        for (var i = 0; i < frames.length; i++) {
+          if (frames[i].src) urls.push(frames[i].src);
+          try { walk(frames[i].contentDocument); } catch(e) {}
+        }
+      } catch(e) {}
+    }
+    walk(document);
+    return JSON.stringify(urls);
+  })()`;
+
   function refresh() {
     chrome.devtools.inspectedWindow.getResources((resources) => {
       let firstDocument = true;
@@ -23,7 +41,20 @@ function createListener(
           }
         }
       }
-      setUrls(Array.from(frameUrls));
+
+      // Also discover nested iframes via DOM traversal
+      chrome.devtools.inspectedWindow.eval(discoverFramesCode, (result) => {
+        if (result) {
+          try {
+            for (const url of JSON.parse(result as unknown as string)) {
+              frameUrls.add(url);
+            }
+          } catch {
+            // Ignore malformed JSON from eval
+          }
+        }
+        setUrls(Array.from(frameUrls));
+      });
     });
   }
   refresh();

--- a/apps/chrome-extension/src/pixi-panel.ts
+++ b/apps/chrome-extension/src/pixi-panel.ts
@@ -10,6 +10,8 @@ function createListener(
   setUrls: (urls: string[]) => void,
   setRefresh: (fn: () => void) => void,
 ) {
+  let lastFrameUrls = "";
+
   function refresh() {
     chrome.devtools.inspectedWindow.getResources((resources) => {
       let firstDocument = true;
@@ -23,7 +25,12 @@ function createListener(
           }
         }
       }
-      setUrls(Array.from(frameUrls));
+      const urls = Array.from(frameUrls);
+      const key = urls.join("\n");
+      if (key !== lastFrameUrls) {
+        lastFrameUrls = key;
+        setUrls(urls);
+      }
     });
   }
   refresh();
@@ -35,8 +42,16 @@ function createListener(
     }
   }
   chrome.devtools.inspectedWindow.onResourceAdded.addListener(callback);
+
+  // Periodically re-scan for frames that onResourceAdded may have missed
+  // (common with cross-origin iframes loaded after initial page render).
+  // The lastFrameUrls dedup ensures setUrls only fires when the frame list
+  // actually changes, making this a no-op once frames stabilize.
+  const rescanInterval = setInterval(refresh, 2_000);
+
   return () => {
     chrome.devtools.inspectedWindow.onResourceAdded.removeListener(callback);
+    clearInterval(rescanInterval);
   };
 }
 

--- a/packages/pixi-panel/src/PixiPanel.svelte
+++ b/packages/pixi-panel/src/PixiPanel.svelte
@@ -91,6 +91,17 @@
   function onerror(target: string, err: Error) {
     console.warn(err);
     clearTimeout(restoreTimer);
+
+    // If the error indicates the frame context is gone, disconnect immediately
+    // to prevent further eval calls from corrupting Chrome's frame tracking.
+    if (err.message.includes("Object not found")) {
+      available.delete(target);
+      active = undefined;
+      errorMessage = "";
+      refresh?.();
+      return;
+    }
+
     refresh?.();
     restoreTimer = window.setTimeout(() => {
       errorMessage = err.message;


### PR DESCRIPTION
## Problem

When a PixiJS app runs inside a cross-origin iframe (e.g. localhost:5173 embedded in a wrapper at localhost:10100), the onResourceAdded event does not reliably fire for the iframe document. This causes the PixiJS panel to permanently show the setup instructions instead of connecting to the app.

This is a common setup when using game development servers that wrap the game client in a host page (e.g. GDK local server embedding a Vite dev server).

## Root Cause

Chrome's `getResources()` and `onResourceAdded` fail to report nested cross-origin iframes after SPA navigation. When the user navigates away from the game page and back, Chrome never re-reports the nested iframe as a resource, leaving the panel permanently unable to find it.

Additionally, the frame URL dedup logic prevented re-detection after page reload since the URL set hadn't changed (even though the execution context was invalidated).

## Fix

1. **Periodic `getResources()` fallback** (commit 1): Add a 2-second interval as a safety net for when `onResourceAdded` misses frames.

2. **Remove frame URL dedup** (commit 2): Always call `setUrls` so frames can be re-detected after context invalidation (page reload).

3. **DOM-based iframe discovery** (commit 3): Probe the DOM recursively via `querySelectorAll('iframe')`, walking into same-origin `contentDocument` trees to find nested cross-origin iframe `src` URLs that the resource API missed. Also bail immediately on "Object not found" errors to prevent eval spam against dead frame contexts from corrupting Chrome's frame tracking.